### PR TITLE
v 1.3.6 Stabe

### DIFF
--- a/LogUploader/Data/CachedLog.cs
+++ b/LogUploader/Data/CachedLog.cs
@@ -193,7 +193,10 @@ namespace LogUploader.Data
             DataCorrected = true;
             Duration = GetDuration((string)data["duration"]);
             Succsess = (bool)data["success"];
-            RemainingHealth = GetRemainingHealth((JArray)data["targets"], BossID);
+            if (BossID == Boss.Get(eBosses.Desmina).ID)
+                RemainingHealth = Succsess ? 0 : 100;
+            else
+                RemainingHealth = GetRemainingHealth((JArray)data["targets"], BossID);
             IsCM = (bool)data["isCM"];
             ApplySimpleLog(new SimpleLogJson(data));
         }

--- a/LogUploader/Data/DataConfig.json
+++ b/LogUploader/Data/DataConfig.json
@@ -148,6 +148,24 @@
           "NameEN": "Snowdendrifts",
           "NameDE": "Schneekulenhölen",
           "AvatarURL": "https://wiki.guildwars2.com/images/0/05/Destroyer_Harpy.jpg"
+        },
+        {
+          "ID": 8,
+          "NameEN": "Caledon Forest",
+          "NameDE": "Caledonwald",
+          "AvatarURL": "https://wiki.guildwars2.com/images/0/05/Destroyer_Harpy.jpg"
+        },
+        {
+          "ID": 9,
+          "NameEN": "Bloodtide Coast",
+          "NameDE": "Blutstrom-Küste",
+          "AvatarURL": "https://wiki.guildwars2.com/images/0/05/Destroyer_Harpy.jpg"
+        },
+        {
+          "ID": 10,
+          "NameEN": "Fireheart Rise",
+          "NameDE": "Feuerherzhügel",
+          "AvatarURL": "https://wiki.guildwars2.com/images/0/05/Destroyer_Harpy.jpg"
         }
       ],
       "Training": [
@@ -726,7 +744,7 @@
         "GameAreaName": "DragonResponseMissions",
         "GameAreaID": 2,
         "DiscordEmote": ":fire:",
-        "AvatarURL": "https://wiki.guildwars2.com/images/7/7d/Destroyer_Troll.jpg",
+        "AvatarURL": "https://wiki.guildwars2.com/images/f/fe/Destroyer_Crab.jpg",
         "RaidOrgaPlusID": -1
       },
       {
@@ -752,7 +770,7 @@
         "GameAreaName": "DragonResponseMissions",
         "GameAreaID": 4,
         "DiscordEmote": ":fire:",
-        "AvatarURL": "https://wiki.guildwars2.com/images/0/05/Destroyer_Harpy.jpg",
+        "AvatarURL": "https://wiki.guildwars2.com/images/d/dc/Destroyer_Emberknight.jpg",
         "RaidOrgaPlusID": -1
       },
       {
@@ -765,7 +783,7 @@
         "GameAreaName": "DragonResponseMissions",
         "GameAreaID": 5,
         "DiscordEmote": ":fire:",
-        "AvatarURL": "https://wiki.guildwars2.com/images/0/05/Destroyer_Harpy.jpg",
+        "AvatarURL": "https://wiki.guildwars2.com/images/7/77/Destroyer_Wyvern.jpg",
         "RaidOrgaPlusID": -1
       },
       {
@@ -778,7 +796,7 @@
         "GameAreaName": "DragonResponseMissions",
         "GameAreaID": 6,
         "DiscordEmote": ":snowflake:",
-        "AvatarURL": "https://wiki.guildwars2.com/images/0/05/Destroyer_Harpy.jpg",
+        "AvatarURL": "https://wiki.guildwars2.com/images/b/b9/Bors_of_the_Ice_Gavel.jpg",
         "RaidOrgaPlusID": -1
       },
       {
@@ -791,7 +809,46 @@
         "GameAreaName": "DragonResponseMissions",
         "GameAreaID": 7,
         "DiscordEmote": ":snowflake:",
-        "AvatarURL": "https://wiki.guildwars2.com/images/0/05/Destroyer_Harpy.jpg",
+        "AvatarURL": "https://wiki.guildwars2.com/images/3/34/Ryland_Steelcatcher.jpg",
+        "RaidOrgaPlusID": -1
+      },
+      {
+        "ID": 23375,
+        "NameEN": "Frost Colossus",
+        "NameDE": "Frost Koloss",
+        "FolderEN": "Frost Colossus",
+        "FolderDE": "Frost Koloss",
+        "EiName": "Frost Colossus",
+        "GameAreaName": "DragonResponseMissions",
+        "GameAreaID": 8,
+        "DiscordEmote": ":snowflake:",
+        "AvatarURL": "https://wiki.guildwars2.com/images/1/1f/Legendary_Icebrood_Construct_%28Bjora_Marches%29.jpg",
+        "RaidOrgaPlusID": -1
+      },
+      {
+        "ID": 23298,
+        "NameEN": "Tribune Splitwall",
+        "NameDE": "Tribun Mauerspalter",
+        "FolderEN": "Tribune Splitwall",
+        "FolderDE": "Tribun Mauerspalter",
+        "EiName": "Tribun Spaltwand",
+        "GameAreaName": "DragonResponseMissions",
+        "GameAreaID": 9,
+        "DiscordEmote": ":snowflake:",
+        "AvatarURL": "https://wiki.guildwars2.com/images/0/06/Tribune_Splitwall.jpg",
+        "RaidOrgaPlusID": -1
+      },
+      {
+        "ID": 23432,
+        "NameEN": "Tribune Splitgold",
+        "NameDE": "Tribun Spaltgold",
+        "FolderEN": "Tribune Splitgold",
+        "FolderDE": "Tribun Spaltgold",
+        "EiName": "Tribun Splitgold",
+        "GameAreaName": "DragonResponseMissions",
+        "GameAreaID": 10,
+        "DiscordEmote": ":snowflake:",
+        "AvatarURL": "https://wiki.guildwars2.com/images/9/90/Tribune_Splitgold.jpg",
         "RaidOrgaPlusID": -1
       },
       {

--- a/LogUploader/Data/RaidOrgaPlus/Position.cs
+++ b/LogUploader/Data/RaidOrgaPlus/Position.cs
@@ -54,13 +54,16 @@ namespace LogUploader.Data.RaidOrgaPlus
             AccName = "";
         }
 
-        internal void UpdateProffessionRole(Profession @class, Role role)
+        internal void UpdateProffessionRole(Profession @class, Role role, bool overrideTank = false)
         {
             Profession = @class;
             if (Role == Role.Empty)
                 Role = role;
             //Override if RO+ and my guess just differ by power and condi role
             else if ((Role == Role.Power || Role == Role.Condi) && (role == Role.Power || role == Role.Condi))
+                Role = role;
+            //Override toughness tanks
+            else if (overrideTank && (Role == Role.Tank || role == Role.Tank))
                 Role = role;
         }
 

--- a/LogUploader/Data/RaidOrgaPlus/Position.cs
+++ b/LogUploader/Data/RaidOrgaPlus/Position.cs
@@ -65,6 +65,8 @@ namespace LogUploader.Data.RaidOrgaPlus
             //Override toughness tanks
             else if (overrideTank && (Role == Role.Tank || role == Role.Tank))
                 Role = role;
+            else if (!(new []{ eProfession.Warrior, eProfession.Berserker, eProfession.Spellbreaker }).Contains(@class.ProfessionEnum) && Role == Role.Banner)
+                Role = role;
         }
 
         internal void Set(RoPlusPlayer player)

--- a/LogUploader/Data/SimpleLogJson.cs
+++ b/LogUploader/Data/SimpleLogJson.cs
@@ -25,6 +25,7 @@ namespace LogUploader.Data
                 .Select(targetData => new SimmpleTarget((JObject)targetData))
                 .ToList();
             Players = ((JArray)parsed["players"])
+                .Where(playerData => !(bool) (playerData["friendlyNPC"] ?? false))
                 .Select(playerData => new SimplePlayer((JObject)playerData, Version))
                 .ToList();
 

--- a/LogUploader/GUIs/LoadingBar.cs
+++ b/LogUploader/GUIs/LoadingBar.cs
@@ -45,8 +45,8 @@ namespace LogUploader.GUIs
 
         private void DoWork()
         {
-            Work(Cts.Token, (a) => Invoke(a), new Progress<ProgressMessage>(ProgressHandler));
-
+            GP.ExecuteSecure(() => Work(Cts.Token, (a) => Invoke(a), new Progress<ProgressMessage>(ProgressHandler)));
+            
             Action update = Close;
             this.Invoke(update);
         }

--- a/LogUploader/Helper/Helper.cs
+++ b/LogUploader/Helper/Helper.cs
@@ -1,10 +1,12 @@
 ﻿using Extensiones;
 using LogUploader.Data;
+using LogUploader.GUIs;
 using LogUploader.Languages;
 using LogUploader.Properties;
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
@@ -112,6 +114,67 @@ namespace LogUploader.Helper
                     return r;
             }
             return Data.RaidOrgaPlus.Role.Empty;
+        }
+
+        public static bool ExecuteSecure(Action a, System.Windows.Forms.IWin32Window parent = null, bool CrashProgramm = false)
+        {
+            bool res = false;
+            res = ExecuteSecure(() => { a(); return true; }, parent, CrashProgramm);
+            return res;
+        }
+
+        public static T ExecuteSecure<T>(Func<T> f, System.Windows.Forms.IWin32Window parent = null, bool CrashProgramm = false)
+        {
+            try
+            {
+                return f();
+            }
+            catch (Win32Exception e)
+            {
+                Logger.Error("Win32 Error Code: " + e.NativeErrorCode + " (native) " + e.ErrorCode + " (managed)");
+                Logger.LogException(e);
+                //MessageBox.Show(GetWin23ExeptionMessage(e), "Win32 error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                var errorUI = new FatalErrorUI("Win32 error", GetWin23ExeptionMessage(e));
+                if (parent != null) errorUI.ShowDialog(parent);
+                if (CrashProgramm) Program.Exit(ExitCode.WIN32_EXCPTION);
+            }
+            catch (Exception e)
+            {
+                Logger.Error("Normal ERROR");
+                Logger.LogException(e);
+                //MessageBox.Show(GetExceptionMessage(e), "Normal Exception", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                var errorUI = new FatalErrorUI("Normal Exception", GetExceptionMessage(e));
+                if (parent != null) errorUI.ShowDialog(parent);
+                if (CrashProgramm) Program.Exit(ExitCode.CLR_EXCPTION);
+            }
+            return default;
+        }
+
+        private static string GetExceptionMessage(Exception e)
+        {
+            return $"Exception: {e.GetType()}\n" +
+                                $"Message: {e.Message}\n" +
+                                "StacTrace:\n" +
+                                $"{e.StackTrace}";
+        }
+
+        private static string GetWin23ExeptionMessage(Win32Exception e)
+        {
+            var res = $"Exception: {e.GetType()}\n" +
+                                    $"Message: {e.Message}\n" +
+                                    $"NativeErrorCode: {e.NativeErrorCode}\n" +
+                                    $"ErrorCode: {e.ErrorCode}\n";
+            try
+            {
+                res += $"Data: {string.Join("\n", e?.Data?.Keys.Cast<object>().Select(k => k.ToString() + " : " + e.Data[k].ToString()))}\n";
+            }
+            catch (Exception)
+            { }
+            res += $"\nStackTrace: " +
+                $"{e.StackTrace}";
+
+
+            return res;
         }
     }
 

--- a/LogUploader/Helper/Helper.cs
+++ b/LogUploader/Helper/Helper.cs
@@ -116,14 +116,14 @@ namespace LogUploader.Helper
             return Data.RaidOrgaPlus.Role.Empty;
         }
 
-        public static bool ExecuteSecure(Action a, System.Windows.Forms.IWin32Window parent = null, bool CrashProgramm = false)
+        public static bool ExecuteSecure(Action a, bool CrashProgramm = false)
         {
             bool res = false;
-            res = ExecuteSecure(() => { a(); return true; }, parent, CrashProgramm);
+            res = ExecuteSecure(() => { a(); return true; }, CrashProgramm);
             return res;
         }
 
-        public static T ExecuteSecure<T>(Func<T> f, System.Windows.Forms.IWin32Window parent = null, bool CrashProgramm = false)
+        public static T ExecuteSecure<T>(Func<T> f, bool CrashProgramm = false)
         {
             try
             {
@@ -133,19 +133,23 @@ namespace LogUploader.Helper
             {
                 Logger.Error("Win32 Error Code: " + e.NativeErrorCode + " (native) " + e.ErrorCode + " (managed)");
                 Logger.LogException(e);
-                //MessageBox.Show(GetWin23ExeptionMessage(e), "Win32 error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                var errorUI = new FatalErrorUI("Win32 error", GetWin23ExeptionMessage(e));
-                if (parent != null) errorUI.ShowDialog(parent);
-                if (CrashProgramm) Program.Exit(ExitCode.WIN32_EXCPTION);
+                if (CrashProgramm)
+                {
+                    var errorUI = new FatalErrorUI("Win32 error", GetWin23ExeptionMessage(e));
+                    errorUI.ShowDialog();
+                    Program.Exit(ExitCode.WIN32_EXCPTION);
+                }
             }
             catch (Exception e)
             {
                 Logger.Error("Normal ERROR");
                 Logger.LogException(e);
-                //MessageBox.Show(GetExceptionMessage(e), "Normal Exception", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                var errorUI = new FatalErrorUI("Normal Exception", GetExceptionMessage(e));
-                if (parent != null) errorUI.ShowDialog(parent);
-                if (CrashProgramm) Program.Exit(ExitCode.CLR_EXCPTION);
+                if (CrashProgramm)
+                {
+                    var errorUI = new FatalErrorUI("Normal Exception", GetExceptionMessage(e));
+                    errorUI.ShowDialog();
+                    Program.Exit(ExitCode.CLR_EXCPTION);
+                }
             }
             return default;
         }

--- a/LogUploader/Helper/Logger.cs
+++ b/LogUploader/Helper/Logger.cs
@@ -221,9 +221,16 @@ namespace LogUploader.Helper
                 Error("Cannot log null excption", cmn, line, cfp);
                 return;
             }
-            Error("Exception: " + e.GetType().ToString(), cmn, line, cfp);
-            Error("Message:" + e.Message, cmn, line, cfp);
-            Error("Stacktrace:" + Environment.NewLine + e.StackTrace, cmn, line, cfp);
+            for (int i = 0; i < 16; i++)
+            {
+                Error("Exception: " + e.GetType().ToString(), cmn, line, cfp);
+                Error("Message:" + e.Message, cmn, line, cfp);
+                Error("Stacktrace:" + Environment.NewLine + e.StackTrace, cmn, line, cfp);
+                if (e.InnerException == null) break;
+                else e = e.InnerException;
+            }
+
+
         }
 
         private static string CreateCaller(string cmn, int line, string cfp)

--- a/LogUploader/Helper/RaidOrgaPlus/Encounter.cs
+++ b/LogUploader/Helper/RaidOrgaPlus/Encounter.cs
@@ -220,6 +220,25 @@ namespace LogUploader.Helper.RaidOrgaPlus
             FillUpDps();
         }
 
+        internal void RefineRoles()
+        {
+            if (TC.Players.Any(p => p.Role == Role.Banner))
+            {
+                var tcBanners = TC.Players.Where(p => p.Role == Role.Banner && (p.Profession == eProfession.Warrior || p.Profession == eProfession.Berserker || p.Profession == eProfession.Spellbreaker)).Select(p => p.AccName);
+                var actualWarriers = Players.Where(p => p.Class == eProfession.Warrior || p.Class == eProfession.Berserker || p.Class == eProfession.Spellbreaker);
+                if (actualWarriers.Any(p => tcBanners.Contains(p.AccountName)))
+                {
+                    foreach (var actualWarrier in actualWarriers)
+                    {
+                        if (tcBanners.Contains(actualWarrier.AccountName))
+                            actualWarrier.Role = Role.Banner;
+                        else
+                            SetDps(actualWarrier);
+                    }
+                }
+            }
+        }
+
         private void SetQadim2Pylons()
         {
             var kiters = Players.OrderBy(p => p.DPS).Where(p => p.Class == eProfession.Deadeye || p.Class == eProfession.Scourge);
@@ -294,11 +313,16 @@ namespace LogUploader.Helper.RaidOrgaPlus
         {
             foreach (var player in Players.Where(p => p.Role == Role.Empty))
             {
-                if (player.PDPS < player.CDPS)
-                    player.Role = Role.Condi;
-                else
-                    player.Role = Role.Power;
+                SetDps(player);
             }
+        }
+
+        private static void SetDps(RoPlusPlayer player)
+        {
+            if (player.PDPS < player.CDPS)
+                player.Role = Role.Condi;
+            else
+                player.Role = Role.Power;
         }
 
         internal void RemoveNotAttededPlayers()

--- a/LogUploader/Helper/RaidOrgaPlus/Encounter.cs
+++ b/LogUploader/Helper/RaidOrgaPlus/Encounter.cs
@@ -11,22 +11,43 @@ namespace LogUploader.Helper.RaidOrgaPlus
     /// </summary>
     public class Encounter
     {
-        public List<RoPlusPlayer> Players { get; set; } = new List<RoPlusPlayer>();
+        public List<RoPlusPlayer> Players { get; set; }
         public Boss Boss { get; set; }
         public TeamComp TC { get; set; }
+
+        private static readonly Boss[] BossRequiresExclude = new Boss[] { 
+            Boss.Get(eBosses.Deimos), // Frindly NPC concept - Desmina
+            Boss.Get(eBosses.Desmina), // Frindly NCP concept - Saul
+            Boss.Get(eBosses.ConjuredAmalgamate) // Sword fake Player
+        };
 
         public Encounter(TeamComp tc, CachedLog log, Raid r)
         {
             TC = tc;
             Boss = tc.Encounter;
-            Players.AddRange(log.PlayersNew.Select(p => new RoPlusPlayer(p, r)));
-            if (Boss.RaidOrgaPlusID == 20)
-            {
-                var sword = Players.Where(p => !p.AccountName.Contains('.')).FirstOrDefault();
-                if (sword != null)
-                    Players.Remove(sword);
-            }
+            Players = GetPlayersFromLog(log.PlayersNew, r, tc.Encounter);
             tc.Success = log.Succsess;
+        }
+
+        private static List<RoPlusPlayer> GetPlayersFromLog(IEnumerable<SimplePlayer> newPlayer, Raid r, Boss boss)
+        {
+            var players = new List<RoPlusPlayer>();
+            players.AddRange(newPlayer.Select(p => new RoPlusPlayer(p, r)));
+            if (BossRequiresExclude.Contains(boss))
+            {
+                RemoveFakePlayers(players);
+            }
+            return players;
+        }
+
+        private static void RemoveFakePlayers(List<RoPlusPlayer> players)
+        {
+            var nonePlayers = players.Where(p => !p.AccountName.Contains('.'));
+            foreach (var notPlayer in nonePlayers)
+            {
+                if (notPlayer != null)
+                    players.Remove(notPlayer);
+            }
         }
 
         internal void GuessRoles()

--- a/LogUploader/Helper/RaidOrgaPlus/Encounter.cs
+++ b/LogUploader/Helper/RaidOrgaPlus/Encounter.cs
@@ -21,6 +21,8 @@ namespace LogUploader.Helper.RaidOrgaPlus
             Boss.Get(eBosses.ConjuredAmalgamate) // Sword fake Player
         };
 
+        private bool overrideTank = false;
+
         public Encounter(TeamComp tc, CachedLog log, Raid r)
         {
             TC = tc;
@@ -276,6 +278,7 @@ namespace LogUploader.Helper.RaidOrgaPlus
             var maxThougness = orderdPlayers.Max(p => p.Toughness);
             if (maxThougness == 0) return;
             orderdPlayers.Where(p => p.Toughness == maxThougness).First().Role = Role.Tank;
+            overrideTank = true;
         }
 
 
@@ -359,7 +362,7 @@ namespace LogUploader.Helper.RaidOrgaPlus
                 if (!player.IsLFG && TC.Exists(player.AccountName))
                 {
                     Position pos = TC.GetByName(player.AccountName);
-                    pos.UpdateProffessionRole(player.Class, player.Role);
+                    pos.UpdateProffessionRole(player.Class, player.Role, overrideTank);
                 }
             }
         }

--- a/LogUploader/Helper/RaidOrgaPlus/RaidOrgaPlusConnector.cs
+++ b/LogUploader/Helper/RaidOrgaPlus/RaidOrgaPlusConnector.cs
@@ -110,7 +110,7 @@ namespace LogUploader.Helper.RaidOrgaPlus
                     (long)termin["raidID"],
                     DateTime.Parse(((string)termin["date"]).Split(' ').Last(), System.Globalization.CultureInfo.GetCultureInfo("de-de")),
                     TimeSpan.Parse((string)termin["time"] + ":00"),
-                    TimeSpan.Parse((string)termin["endtime"] + ":00"),
+                    TimeSpan.Parse(((string)termin["endtime"] ?? (string)termin["time"]) + ":00"),
                     (string)termin["name"]
                     ));
 

--- a/LogUploader/Helper/RaidOrgaPlus/RaidOrgaPlusDataWorker.cs
+++ b/LogUploader/Helper/RaidOrgaPlus/RaidOrgaPlusDataWorker.cs
@@ -168,6 +168,7 @@ namespace LogUploader.Helper.RaidOrgaPlus
                 progress?.Report(new ProgressMessage((double)(index) / (double)count, $"{(int)(count + 1)} of {count}"));
                 encounter.FillTeamComp();
                 encounter.GuessRoles();
+                encounter.RefineRoles();
                 encounter.RemoveNotAttededPlayers();
                 encounter.RemoveDuplicates();
                 encounter.UpdateNamedPlayers();

--- a/LogUploader/Helper/RaidOrgaPlus/RaidOrgaPlusDataWorker.cs
+++ b/LogUploader/Helper/RaidOrgaPlus/RaidOrgaPlusDataWorker.cs
@@ -21,6 +21,7 @@ namespace LogUploader.Helper.RaidOrgaPlus
             logs = OnlyGetOnePerBoss(logs);
             CondenseStatues(logs);
 
+            MatchCMandNormal(raid, logs);
             progress?.Report(new ProgressMessage(0.03, "Remove unused bosses from RO+ data"));
             RemoveUnused(raid, logs);
 
@@ -107,9 +108,36 @@ namespace LogUploader.Helper.RaidOrgaPlus
 
         private static void RemoveUnused(Raid raid, IEnumerable<CachedLog> logs)
         {
-            raid.Bosses = raid.Bosses.Where(boss => 
+            raid.Bosses = raid.Bosses.Where(boss =>
             logs.Any(log => Boss.GetByID(log.BossID).RaidOrgaPlusID == boss.BossID && log.IsCM == boss.IsCM)
             ).ToList();
+
+        }
+
+        private static void MatchCMandNormal(Raid raid, IEnumerable<ICachedLog> logs)
+        {
+            foreach (var boss in raid.Bosses.GroupBy(b => b.BossID))
+            {
+                var count = boss.Count();
+                var anyNormal = boss.Any(b => !b.IsCM);
+                var anyCM = boss.Any(b => b.IsCM);
+
+                var raidBoss = logs.Where(b => b.ID == boss.Key);
+                var raidAnyNormal = raidBoss.Any(b => !b.IsCM);
+                var raidAnyCM = raidBoss.Any(b => !b.IsCM);
+
+                var succLogs = raidBoss.Where(b => b.Succsess);
+                if (count == 1 && ((anyCM && !anyNormal) || (!anyCM && anyNormal)))
+                {
+                    //Only one CM or one normal in RO+
+                    if (succLogs.Count() == 1)
+                        boss.First().IsCM = succLogs.First().IsCM;
+                    else if (!raidAnyNormal)
+                        boss.First().IsCM = true;
+                    else if (!raidAnyCM)
+                        boss.First().IsCM = false;
+                }
+            }
         }
 
         private static IEnumerable<CachedLog> OnlyGetOnePerBoss(IEnumerable<CachedLog> logs)

--- a/LogUploader/Helper/RaidOrgaPlus/RaidOrgaPlusDataWorker.cs
+++ b/LogUploader/Helper/RaidOrgaPlus/RaidOrgaPlusDataWorker.cs
@@ -114,7 +114,7 @@ namespace LogUploader.Helper.RaidOrgaPlus
 
         }
 
-        private static void MatchCMandNormal(Raid raid, IEnumerable<ICachedLog> logs)
+        private static void MatchCMandNormal(Raid raid, IEnumerable<CachedLog> logs)
         {
             foreach (var boss in raid.Bosses.GroupBy(b => b.BossID))
             {

--- a/LogUploader/Language/Language.cs
+++ b/LogUploader/Language/Language.cs
@@ -48,17 +48,31 @@ namespace LogUploader.Languages
             //Exception "System.IO.FileNotFoundException: 'Die Datei oder Assembly "LogUploader.XmlSerializers, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" oder eine Abhängigkeit davon wurde nicht gefunden. Das System kann die angegebene Datei nicht finden.'"
             //Will not be fixed by microsoft. cant do anything about it.
             var ser = new System.Xml.Serialization.XmlSerializer(typeof(XMLLanguage));
-            using (StringReader sr = new StringReader(File.ReadAllText(exePath + @"\Data\English.xml", Encoding.UTF8)))
+            using (StringReader sr = new StringReader(ReadFile(exePath + @"\Data\English.xml")))
             {
                 English = (XMLLanguage)ser.Deserialize(sr);
                 English.Culture = new CultureInfo("en-us");
             }
-            using (StringReader sr = new StringReader(File.ReadAllText(exePath + @"\Data\German.xml", Encoding.UTF8)))
+            using (StringReader sr = new StringReader(ReadFile(exePath + @"\Data\German.xml")))
             {
                 German = (XMLLanguage)ser.Deserialize(sr);
                 German.Culture = new CultureInfo("de-de");
             }
             Current = m_Current;
+        }
+
+        private static string ReadFile(string filePath)
+        {
+            try
+            {
+                return File.ReadAllText(filePath, Encoding.UTF8);
+            }
+            catch (Exception e)
+            {
+                Logger.Error($@"Unable to read localisation file ""{filePath}"".");
+                Logger.LogException(e);
+                throw e;
+            }
         }
 
         public static void XMLModeEnable(bool enable)

--- a/LogUploader/Program.cs
+++ b/LogUploader/Program.cs
@@ -205,7 +205,8 @@ namespace LogUploader
 #elif BETA
 #elif ALPHA
 #else
-            Logger.LogLevel = flags.LogLevel;
+            if (flags.OverrideLogLevel)
+                Logger.LogLevel = flags.LogLevel;
 #endif
 
             progress.Report(new ProgressMessage(0.02, "Loading Settings"));
@@ -524,6 +525,7 @@ namespace LogUploader
             public bool EnableAutoUpload { get; set; }
             public bool ResetSettings { get; set; }
             public eLogLevel LogLevel { get; set; }
+            public bool OverrideLogLevel { get; set; }
 
             public Flags(bool enableAutoUpload = false, bool resetSettings = false, bool enableAutoParse = false, eLogLevel logLevel = eLogLevel.WARN)
             {
@@ -531,10 +533,12 @@ namespace LogUploader
                 ResetSettings = resetSettings;
                 EnableAutoParse = enableAutoParse;
                 LogLevel = logLevel;
+                OverrideLogLevel = false;
             }
 
             public Flags(string[] args) : this()
             {
+                OverrideLogLevel = false;
                 var argumentErrors = "";
                 for (int i = 0; i < args.Length; i++)
                 {
@@ -552,15 +556,19 @@ namespace LogUploader
                             break;
                         case FlagLogLevelDebug:
                             LogLevel = eLogLevel.DEBUG;
+                            OverrideLogLevel = true;
                             break;
                         case FlagLogLevelNormal:
                             LogLevel = eLogLevel.NORMAL;
+                            OverrideLogLevel = true;
                             break;
                         case FlagLogLevelWarning:
                             LogLevel = eLogLevel.WARN;
+                            OverrideLogLevel = true;
                             break;
                         case FlagLogLevelVerbose:
                             LogLevel = eLogLevel.VERBOSE;
+                            OverrideLogLevel = true;
                             break;
                         default:
                             argumentErrors += $"\n- \"{arg}\"";

--- a/LogUploader/Properties/AssemblyInfo.cs
+++ b/LogUploader/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 // übernehmen, indem Sie "*" eingeben:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.3.5.0")]
+[assembly: AssemblyFileVersion("1.3.6.0")]

--- a/LogUploaderSetup/LogUploaderSetup.vdproj
+++ b/LogUploaderSetup/LogUploaderSetup.vdproj
@@ -106,12 +106,6 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_3DF04A203084DA78F1AC22E8A0C59BC4"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_5478B3399FDE4598B2B307E4402FE1AE"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -167,6 +161,12 @@
         {
         "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_4DA52FEED72909480248181EEDC69AFE"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_UNDEFINED"
+        "OwnerKey" = "8:_3DF04A203084DA78F1AC22E8A0C59BC4"
         "MsmSig" = "8:_UNDEFINED"
         }
     }
@@ -839,15 +839,15 @@
         {
         "Name" = "8:Microsoft Visual Studio"
         "ProductName" = "8:Log Uploader"
-        "ProductCode" = "8:{78058013-EFE5-402A-9A92-777AB821A846}"
-        "PackageCode" = "8:{A2C9779E-E80F-4403-BDFF-3473D9305215}"
+        "ProductCode" = "8:{FC5CC3FE-2A2D-485B-BA19-ECF5EFE584C0}"
+        "PackageCode" = "8:{54DBA35B-E4BE-43AD-9301-78BA95D87F3B}"
         "UpgradeCode" = "8:{3F3DD479-F9CF-48EE-8590-B34CEB67C1B3}"
         "AspNetVersion" = "8:4.0.30319.0"
         "RestartWWWService" = "11:FALSE"
         "RemovePreviousVersions" = "11:TRUE"
         "DetectNewerInstalledVersion" = "11:FALSE"
         "InstallAllUsers" = "11:FALSE"
-        "ProductVersion" = "8:1.3.5"
+        "ProductVersion" = "8:1.3.6"
         "Manufacturer" = "8:Bits Inc."
         "ARPHELPTELEPHONE" = "8:"
         "ARPHELPLINK" = "8:https://github.com/ProfBits/LogUploader2"
@@ -1483,7 +1483,7 @@
         {
             "{5259A561-127C-4D43-A0A1-72F10C7B3BF8}:_5478B3399FDE4598B2B307E4402FE1AE"
             {
-            "SourcePath" = "8:..\\LogUploader\\obj\\Debug\\LogUploader.exe"
+            "SourcePath" = "8:..\\LogUploader\\obj\\Release\\LogUploader.exe"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_748D937327AF47B299A3DC5BBB98E3D6"

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,4 +1,5 @@
 # v1.3.6
+14.04.2021
 
 ## Features
 - New Encounters:

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,10 +1,23 @@
+# v1.3.6
+
+## Features
+- New Encounters:
+    - Dragon Response Mission: Caledon Forest
+    - Dragon Response Mission: Bloodtide Coast
+    - Dragon Response Mission: Fireheart Rise
+
+## Bugfixes
+Fixed Chrash if any RaidOrga+ Termin had no endtime
+Fixed verbosity of logging on startup with no logging args
+
 # v1.3.5
+25.02.2021
 
 ## Improvements
 - Support Heralds can now be detected
 
 ## Bugfixes
-- Webhook posts with 'הצü' should possible again
+- Webhook posts with 'הצü' should be possible again
 
 # v1.3.4
 31.01.2021

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -11,6 +11,7 @@
 - Bannar role with non warrier profession is now overritten
 - If a banner warrier is in set in RO+ and was Warrier no additional banner warriors should be added on update RO+
 - Improved general programm stability
+- Normal and CM missmatch between logs and RO+ can be resolved sometimes
 
 ## Bugfixes
 Fixed crash if any RaidOrga+ Termin had no endtime

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -5,6 +5,12 @@
     - Dragon Response Mission: Caledon Forest
     - Dragon Response Mission: Bloodtide Coast
     - Dragon Response Mission: Fireheart Rise
+    
+## Improvements
+- Thoughness tanks are now overritten on RO+ update
+- Bannar role with non warrier profession is now overritten
+- If a banner warrier is in set in RO+ and was Warrier no additional banner warriors should be added on update RO+
+- Improved general programm stability
 
 ## Bugfixes
 Fixed crash if any RaidOrga+ Termin had no endtime

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -7,8 +7,9 @@
     - Dragon Response Mission: Fireheart Rise
 
 ## Bugfixes
-Fixed Chrash if any RaidOrga+ Termin had no endtime
+Fixed crash if any RaidOrga+ Termin had no endtime
 Fixed verbosity of logging on startup with no logging args
+Fixed crash wehn trying to update a River or Deimos Encounter in RO+
 
 # v1.3.5
 25.02.2021


### PR DESCRIPTION
# v1.3.6

## Features
- New Encounters:
    - Dragon Response Mission: Caledon Forest
    - Dragon Response Mission: Bloodtide Coast
    - Dragon Response Mission: Fireheart Rise
    
## Improvements
- Thoughness tanks are now overritten on RO+ update
- Bannar role with non warrier profession is now overritten
- If a banner warrier is in set in RO+ and was Warrier no additional banner warriors should be added on update RO+
- Improved general programm stability
- Normal and CM missmatch between logs and RO+ can be resolved sometimes

## Bugfixes
Fixed crash if any RaidOrga+ Termin had no endtime
Fixed verbosity of logging on startup with no logging args
Fixed crash wehn trying to update a River or Deimos Encounter in RO+